### PR TITLE
fixed a critical path bug

### DIFF
--- a/reload.py
+++ b/reload.py
@@ -278,7 +278,7 @@ def _createTables(ctx):
     )
     conn.autocommit = True
     cursor = conn.cursor()
-    with open("data/tables.sql", encoding="latin-1") as f:
+    with open("/data/tables.sql", encoding="latin-1") as f:
         for line in f:
             logger.info("executing " + line)
             cursor.execute(line)


### PR DESCRIPTION
This PR fixes a critical path bug. Specifically, the table schema file is created in ```/data/tables.sql``` while when loading the file, the path was set as ```data/tables.sql```. I remember when I first worked on the pipeline, this tables.sql file cannot be found, so I run the command manually to create tables.sql file and put in under ```data/tables.sql``` so that pipeline run can find it and run through. While trying to fix the tests, I found this critical bug. This PR will fix it so that when table schemas get changed in the future, changed schemas can be picked up by the pipeline.