### PR TITLE
fix travis test by updating spark hadoop version 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN wget https://archive.apache.org/dist/spark/spark-2.4.8/spark-2.4.8-bin-hadoo
 # RUN wget http://apache.spinellicreations.com/spark/spark-2.4.7/spark-2.4.7-bin-hadoop2.7.tgz && echo "0F5455672045F6110B030CE343C049855B7BA86C0ECB5E39A075FF9D093C7F648DA55DED12E72FFE65D84C32DCD5418A6D764F2D6295A3F894A4286CC80EF478  spark-2.4.7-bin-hadoop2.7.tgz" | sha512sum -c -
 
 RUN tar zxvf spark-2.4.8-bin-hadoop2.7.tgz
-ENV PATH="/spark-3.3.0-bin-hadoop2/bin:${PATH}"
+ENV PATH="/spark-2.4.8-bin-hadoop2/bin:${PATH}"
 # set to 1 to reload data from redcap database
 ENV RELOAD_DATABASE=1
 # set to 1 for one off reload

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN wget https://archive.apache.org/dist/spark/spark-2.4.8/spark-2.4.8-bin-hadoo
 # RUN wget http://apache.spinellicreations.com/spark/spark-2.4.7/spark-2.4.7-bin-hadoop2.7.tgz && echo "0F5455672045F6110B030CE343C049855B7BA86C0ECB5E39A075FF9D093C7F648DA55DED12E72FFE65D84C32DCD5418A6D764F2D6295A3F894A4286CC80EF478  spark-2.4.7-bin-hadoop2.7.tgz" | sha512sum -c -
 
 RUN tar zxvf spark-2.4.8-bin-hadoop2.7.tgz
-ENV PATH="/spark-2.4.8-bin-hadoop2/bin:${PATH}"
+ENV PATH="/spark-2.4.8-bin-hadoop2.7/bin:${PATH}"
 # set to 1 to reload data from redcap database
 ENV RELOAD_DATABASE=1
 # set to 1 for one off reload

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN pip3 install csvkit
 RUN pip3 install  schedule pandas psycopg2-binary  requests flask flask-cors redis rq oslash==0.5.1 tx-functional
 RUN pip3 install git+https://github.com/vaidik/sherlock.git@77742ba91a24f75ee62e1895809901bde018654f
 
-RUN wget https://downloads.apache.org/spark/spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz
+RUN wget https://downloads.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop2.tgz
 # RUN wget https://apache.claz.org/spark/spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz
 # https://apache.claz.org/spark/spark-2.4.7/spark-2.4.7-bin-hadoop2.7.tgz
 #&& echo "0F5455672045F6110B030CE343C049855B7BA86C0ECB5E39A075FF9D093C7F648DA55DED12E72FFE65D84C32DCD5418A6D764F2D6295A3F894A4286CC80EF478  spark-2.4.7-bin-hadoop2.7.tgz" | sha512sum -c -

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,14 +51,14 @@ RUN pip3 install csvkit
 RUN pip3 install  schedule pandas psycopg2-binary  requests flask flask-cors redis rq oslash==0.5.1 tx-functional
 RUN pip3 install git+https://github.com/vaidik/sherlock.git@77742ba91a24f75ee62e1895809901bde018654f
 
-RUN wget https://downloads.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop2.tgz
+RUN wget https://archive.apache.org/dist/spark/spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz
 # RUN wget https://apache.claz.org/spark/spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz
 # https://apache.claz.org/spark/spark-2.4.7/spark-2.4.7-bin-hadoop2.7.tgz
 #&& echo "0F5455672045F6110B030CE343C049855B7BA86C0ECB5E39A075FF9D093C7F648DA55DED12E72FFE65D84C32DCD5418A6D764F2D6295A3F894A4286CC80EF478  spark-2.4.7-bin-hadoop2.7.tgz" | sha512sum -c -
 
 # RUN wget http://apache.spinellicreations.com/spark/spark-2.4.7/spark-2.4.7-bin-hadoop2.7.tgz && echo "0F5455672045F6110B030CE343C049855B7BA86C0ECB5E39A075FF9D093C7F648DA55DED12E72FFE65D84C32DCD5418A6D764F2D6295A3F894A4286CC80EF478  spark-2.4.7-bin-hadoop2.7.tgz" | sha512sum -c -
 
-RUN tar zxvf spark-3.3.0-bin-hadoop2.tgz
+RUN tar zxvf spark-2.4.8-bin-hadoop2.7.tgz
 ENV PATH="/spark-3.3.0-bin-hadoop2/bin:${PATH}"
 # set to 1 to reload data from redcap database
 ENV RELOAD_DATABASE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,8 +58,8 @@ RUN wget https://downloads.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop2.
 
 # RUN wget http://apache.spinellicreations.com/spark/spark-2.4.7/spark-2.4.7-bin-hadoop2.7.tgz && echo "0F5455672045F6110B030CE343C049855B7BA86C0ECB5E39A075FF9D093C7F648DA55DED12E72FFE65D84C32DCD5418A6D764F2D6295A3F894A4286CC80EF478  spark-2.4.7-bin-hadoop2.7.tgz" | sha512sum -c -
 
-RUN tar zxvf spark-2.4.8-bin-hadoop2.7.tgz
-ENV PATH="/spark-2.4.8-bin-hadoop2.7/bin:${PATH}"
+RUN tar zxvf spark-3.3.0-bin-hadoop2.tgz
+ENV PATH="/spark-3.3.0-bin-hadoop2/bin:${PATH}"
 # set to 1 to reload data from redcap database
 ENV RELOAD_DATABASE=1
 # set to 1 for one off reload

--- a/test/redcap/Dockerfile
+++ b/test/redcap/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.7.3-stretch
 
+RUN pip install -U pip
 RUN pip install flask pyopenssl
 
 COPY record.json record.json


### PR DESCRIPTION
The old spark hadoop version we are using has been deprecated since this June, which triggered travis test build error. The reason it works when I built the image locally is that docker pulls the old tgz file from cache even though it cannot be downloaded from the package distribution website. Updating the spark hadoop version should fix the travis test error. I am rebuilding the pipeline docker image with updated version and will test the image to make sure data ingestion and transformation works before merging this PR.